### PR TITLE
Last command cleanup

### DIFF
--- a/src/Commands/LastCommand.php
+++ b/src/Commands/LastCommand.php
@@ -10,10 +10,8 @@ class LastCommand extends Command
 {
     protected function configure()
     {
-        $this
-            ->setName('log:last')
-            ->setDescription('Get the most recent changelog')
-        ;
+        $this->setName('log:last')
+             ->setDescription('Get the most recent changelog');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Commands/LastCommand.php
+++ b/src/Commands/LastCommand.php
@@ -20,6 +20,7 @@ class LastCommand extends Command
 
         if (file_exists(getcwd().'/changelog.md')) {
             $changelog = file_get_contents(getcwd().'/changelog.md');
+        $changelog = $this->getChangeLog();
 
             $changelogParts = explode('----', $changelog);
 
@@ -31,8 +32,19 @@ class LastCommand extends Command
                 }
             }
         } else {
+    /**
+     * Get the current contents of the CHANGELOG
+     *
+     * @return string
+     */
+    protected function getChangeLog()
+    {
+        $contents = @file_get_contents(getcwd() . '/changelog.md');
+        if($contents === false) {
             throw new \Exception("Please run this first: clg log:create {name}", 1);
         }
+        return $contents;
+    }
 
         $time_end = microtime(true);
         $time = $time_end - $time_start;

--- a/src/Commands/LastCommand.php
+++ b/src/Commands/LastCommand.php
@@ -2,11 +2,7 @@
 
 namespace Mlantz\Changelog\Commands;
 
-use Symfony\Component\Yaml\Parser;
-use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Commands/LastCommand.php
+++ b/src/Commands/LastCommand.php
@@ -18,20 +18,21 @@ class LastCommand extends Command
     {
         $time_start = microtime(true);
 
-        if (file_exists(getcwd().'/changelog.md')) {
-            $changelog = file_get_contents(getcwd().'/changelog.md');
         $changelog = $this->getChangeLog();
+        $changes = $this->getChangeLogChanges($changelog, $output);
 
-            $changelogParts = explode('----', $changelog);
-
-            $changes = explode('## [', trim($changelogParts[1]));
-
-            foreach ($changes as $index => $change) {
-                if ($index == 1) {
-                    $output->writeln("\n[$change");
-                }
+        foreach ($changes as $index => $change) {
+            if ($index == 1) {
+                $output->writeln("\n[$change");
             }
-        } else {
+        }
+
+        $time_end = microtime(true);
+        $time = round($time_end - $time_start,5);
+
+        $output->writeln("Completed in: ${time} seconds");
+    }
+
     /**
      * Get the current contents of the CHANGELOG
      *
@@ -48,8 +49,23 @@ class LastCommand extends Command
 
         $time_end = microtime(true);
         $time = $time_end - $time_start;
+    /**
+     * Get the latest changes to the CHANGELOG
+     *
+     * @param  string $changelog
+     * @return array
+     */
+    protected function getChangeLogChanges($changelog)
+    {
+        $changelogParts = explode('----', $changelog);
 
-        $output->writeln("\nCompleted in: ".$time." seconds");
+        if(!isset($changelogParts[1])) {
+            throw new \Exception("Your CHANGELOG is empty. Please add some lines first with the clg log:add command.", 1);
+        }
+
+        $changes = explode('## [', trim($changelogParts[1]));
+
+        return $changes;
     }
 
 }

--- a/src/Commands/LastCommand.php
+++ b/src/Commands/LastCommand.php
@@ -8,12 +8,24 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LastCommand extends Command
 {
+    /**
+     * Set the name and description of the command
+     *
+     * @return void
+     */
     protected function configure()
     {
         $this->setName('log:last')
              ->setDescription('Get the most recent changelog');
     }
 
+    /**
+     * Display the last change in the CHANGELOG
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $time_start = microtime(true);
@@ -47,8 +59,6 @@ class LastCommand extends Command
         return $contents;
     }
 
-        $time_end = microtime(true);
-        $time = $time_end - $time_start;
     /**
      * Get the latest changes to the CHANGELOG
      *


### PR DESCRIPTION
Jim and I were having a few problems with the changelog. When we accidentally ran the `log:last` command when there was no changelog content, it errored out. I modified the last command to check for this, and did some general cleanup. Let me know your thoughts. 